### PR TITLE
Release 1.40.0 (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated build to Kotlin DSL (`build.gradle.kts`, `settings.gradle.kts`) and the Gradle version catalog (`gradle/libs.versions.toml`).
 - Upgraded Gradle wrapper to 9.5.0.
 - Upgraded Shadow plugin to `com.gradleup.shadow` 9.4.1.
-- Adopted property-assignment syntax in build scripts and bound the `shadowJar` task provider once for the `uberjar` task.
+- Adopted property-assignment syntax in build scripts (`mainClass`, `archiveFileName`, `repositoriesMode`).
+- Collapsed the standalone `uberjar` task into `shadowJar` itself — `./gradlew shadowJar` now produces `build/libs/kslides.jar` directly with the custom manifest.
+- Gave the `stage` task an explicit `DefaultTask` type, the `build` group, and a description so it surfaces in `gradle tasks`.
+- Removed `mavenLocal()` from both repository blocks in `settings.gradle.kts`.
+- Alphabetized `[plugins]` entries in `gradle/libs.versions.toml`.
 - Bumped `ben-manes-versions` plugin to 0.54.0.
 - Rewrote the README's build section for Kotlin DSL + the version catalog.
 - Renamed `LICENSE` to `LICENSE.txt`.
@@ -22,10 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `syncRevealJs` Gradle task that unpacks reveal.js assets from the `kslides-core` JAR into `docs/revealjs/`.
 - `CHANGELOG.md` and `RELEASE_NOTES.md` covering history back to the initial commit.
 - `CLAUDE.md` project guidance.
+- `.PHONY` declarations in `Makefile` for every target.
+- `make uber` now honours `$PORT` (matches `Procfile`, defaults to 8080 locally).
 
 ### Removed
 - Legacy `build.gradle` / `settings.gradle` (Groovy DSL).
 - `.travis.yml` (Travis CI config).
+- The `LICENSE*` exclusion in `shadowJar` — third-party LICENSE files are now preserved in the uberjar.
+- Standalone `uberjar` Gradle task (replaced by configuring `shadowJar` directly).
 
 ## [1.30.0] - 2023-11-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.40.0] - 2026-04-29
+
 ### Changed
 - Migrated build to Kotlin DSL (`build.gradle.kts`, `settings.gradle.kts`) and the Gradle version catalog (`gradle/libs.versions.toml`).
-- Upgraded Gradle wrapper to 9.4.1.
+- Upgraded Gradle wrapper to 9.5.0.
 - Upgraded Shadow plugin to `com.gradleup.shadow` 9.4.1.
 - Adopted property-assignment syntax in build scripts and bound the `shadowJar` task provider once for the `uberjar` task.
-- Added `syncRevealJs` task that unpacks reveal.js assets from the `kslides-core` JAR into `docs/revealjs/`.
+- Bumped `ben-manes-versions` plugin to 0.54.0.
+- Rewrote the README's build section for Kotlin DSL + the version catalog.
+- Renamed `LICENSE` to `LICENSE.txt`.
+
+### Added
+- `syncRevealJs` Gradle task that unpacks reveal.js assets from the `kslides-core` JAR into `docs/revealjs/`.
+- `CHANGELOG.md` and `RELEASE_NOTES.md` covering history back to the initial commit.
+- `CLAUDE.md` project guidance.
+
+### Removed
+- Legacy `build.gradle` / `settings.gradle` (Groovy DSL).
+- `.travis.yml` (Travis CI config).
 
 ## [1.30.0] - 2023-11-01
 
@@ -160,7 +173,8 @@ released tag (1.2.1).
 ### 2021-02-15 — Initial commit
 - Repository created.
 
-[Unreleased]: https://github.com/kslides/kslides-template/compare/1.30.0...HEAD
+[Unreleased]: https://github.com/kslides/kslides-template/compare/1.40.0...HEAD
+[1.40.0]: https://github.com/kslides/kslides-template/compare/1.30.0...1.40.0
 [1.30.0]: https://github.com/kslides/kslides-template/compare/1.10.0...1.30.0
 [1.10.0]: https://github.com/kslides/kslides-template/compare/1.9.0...1.10.0
 [1.9.0]: https://github.com/kslides/kslides-template/compare/1.8.0...1.9.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,16 @@ A GitHub template for authoring [kslides](https://github.com/kslides/kslides) pr
 
 The Makefile is a thin wrapper over `./gradlew`:
 
+- `make` (no args) defaults to `versioncheck`
 - `make build` — `./gradlew clean build -xtest` (tests are intentionally skipped here)
-- `make uberjar` — produce `build/libs/kslides.jar` via Shadow
-- `make uber` — build the uberjar and run it (`java -jar build/libs/kslides.jar`)
-- `make stage` — `clean` + `uberjar`; this is what Heroku invokes (see `Procfile`)
+- `make build-all` — alias for `make stage`; the Gradle `stage` task already declares `dependsOn("clean", "shadowJar")`
+- `make uberjar` — invokes `./gradlew shadowJar`, which produces `build/libs/kslides.jar` directly with the custom manifest (there is no separate `uberjar` Gradle task — that wrapper was collapsed into `shadowJar` in 1.40.0)
+- `make uber` — build the uberjar and run it (`java -DPORT=$${PORT:-8080} -jar build/libs/kslides.jar`); honours `$PORT` if set, otherwise falls back to 8080
+- `make stage` — `./gradlew stage`; this is what Heroku invokes (see `Procfile`)
 - `make dist` — `./gradlew installDist`
 - `make sync-revealjs` — runs the `syncRevealJs` task (see Architecture)
 - `make versioncheck` — `./gradlew dependencyUpdates` (ben-manes plugin); must use `--no-configuration-cache --no-parallel`
-- `make upgrade-wrapper` — re-pin the Gradle wrapper version
+- `make upgrade-wrapper` — re-pin the Gradle wrapper version (hardcoded; bump in lockstep with `gradle/wrapper/gradle-wrapper.properties`)
 
 Run `fun main()` in `Slides.kt` directly from IntelliJ (green arrow) to generate slides — that's the primary author workflow, not a Gradle task.
 
@@ -51,6 +53,9 @@ This is the single most surprising thing about the project — the same logical 
 - JVM toolchain: 17 (foojay resolver convention; users without a local JDK 17 get one auto-provisioned).
 - `mainName` in `build.gradle.kts` (currently `"SlidesKt"`) must match the Kotlin file users want to serve over HTTP. The comment above it is the documented extension point for forks.
 - `version` in `build.gradle.kts` is the *template* version, not the kslides library version (which lives in `libs.versions.toml`). Keep them distinct.
+- `shadowJar` is configured directly (no `Jar`-typed wrapper task) — it sets `archiveFileName = "kslides.jar"` and the `Implementation-*` / `Main-Class` manifest attributes itself. To customize the uberjar, edit the `tasks.named<ShadowJar>("shadowJar") { … }` block.
+- Configuration cache is on (`org.gradle.configuration-cache=true` in `gradle.properties`). New tasks must be CC-compatible; ben-manes' `dependencyUpdates` is the only known incompatible task and `make versioncheck` opts out for it.
+- Repositories are locked down: `settings.gradle.kts` uses `FAIL_ON_PROJECT_REPOS` and resolves only from `mavenCentral()` (no `mavenLocal()` — local snapshots can't be picked up without temporarily editing the file).
 
 ## Conventions for edits to this template
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-A GitHub template for authoring [kslides](https://github.com/kslides/kslides) presentations. End users hit "Use this template" to fork it, then edit `src/main/kotlin/Slides.kt` to author their deck. Changes here flow downstream to every fork, so keep the template minimal and back-compat where possible — see `CHANGELOG.md` for the running history users are expected to track.
+A GitHub template for authoring [kslides](https://github.com/kslides/kslides) presentations. End users hit "Use this template" to fork it, then edit `src/main/kotlin/Slides.kt` to author their deck. Changes here flow downstream to every fork, so keep the template minimal and back-compat where possible — see `CHANGELOG.md` (per-version diff) and `RELEASE_NOTES.md` (narrative) for the running history users are expected to track.
 
 ## Build & run
 
@@ -56,4 +56,4 @@ This is the single most surprising thing about the project — the same logical 
 ## Conventions for edits to this template
 
 - Anything user-facing (groupId placeholder `com.github.username`, `mainName`, `Slides.kt` example content) is meant to be edited downstream — keep it obvious and commented, don't over-engineer.
-- Update `CHANGELOG.md` for any change a downstream fork would need to mirror.
+- For any change a downstream fork would need to mirror, update **both** `CHANGELOG.md` (Keep-a-Changelog format, per-version structured entry) and `RELEASE_NOTES.md` (narrative highlights). Tag-driven releases also need the template `version` in `build.gradle.kts` bumped — keep all three in sync in the same commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,6 @@ This is the single most surprising thing about the project — the same logical 
 - JVM toolchain: 17 (foojay resolver convention; users without a local JDK 17 get one auto-provisioned).
 - `mainName` in `build.gradle.kts` (currently `"SlidesKt"`) must match the Kotlin file users want to serve over HTTP. The comment above it is the documented extension point for forks.
 - `version` in `build.gradle.kts` is the *template* version, not the kslides library version (which lives in `libs.versions.toml`). Keep them distinct.
-- Shadow excludes `LICENSE*` from the uberjar; if you need to ship third-party licenses, revisit that.
 
 ## Conventions for edits to this template
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
+.PHONY: default build-all clean build uberjar uber dist stage sync-revealjs versioncheck upgrade-wrapper
+
 default: versioncheck
 
-build-all: clean stage
+# stage already depends on clean in Gradle (see build.gradle.kts).
+build-all: stage
 
 clean:
 	./gradlew clean
@@ -11,8 +14,9 @@ build: clean
 uberjar:
 	./gradlew shadowJar
 
+# Matches Procfile (-DPORT=$PORT); falls back to 8080 for local runs.
 uber: uberjar
-	java -jar build/libs/kslides.jar
+	java -DPORT=$${PORT:-8080} -jar build/libs/kslides.jar
 
 dist:
 	./gradlew installDist
@@ -26,6 +30,7 @@ stage:
 sync-revealjs:
 	./gradlew syncRevealJs
 
+# ben-manes' dependencyUpdates is not configuration-cache compatible.
 versioncheck:
 	./gradlew dependencyUpdates --no-configuration-cache --no-parallel
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build: clean
 	./gradlew build -xtest
 
 uberjar:
-	./gradlew uberjar
+	./gradlew shadowJar
 
 uber: uberjar
 	java -jar build/libs/kslides.jar

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ dependencyResolutionManagement {
     repositoriesMode = FAIL_ON_PROJECT_REPOS
     repositories {
         mavenCentral()
-        mavenLocal()
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # kslides Template
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/kslides/kslides-template)
-[![Build Status](https://app.travis-ci.com/kslides/kslides-template.svg?branch=master)](https://app.travis-ci.com/kslides/kslides-template)
-[![Kotlin version](https://img.shields.io/badge/kotlin-2.1.20-red?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin version](https://img.shields.io/badge/kotlin-2.3.21-red?logo=kotlin)](http://kotlinlang.org)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/ed16ddd9-ab47-4e9d-8e37-807edded7a6e/deploy-status)](https://app.netlify.com/sites/kslides-template/deploys)
 
 A template repo for authoring [kslides](https://github.com/kslides/kslides) presentation.
@@ -14,9 +13,11 @@ A template repo for authoring [kslides](https://github.com/kslides/kslides) pres
 To create a kslides presentation, generate a new repository using this
 repo as a [template](https://github.com/kslides/kslides-template/generate).
 
-All changes to this template are documented in the 
-[CHANGELOG.md](https://github.com/kslides/kslides-template/blob/master/CHANGELOG.md) file.
-Check back occasionally for any changes that should to be incorporated into your kslides repo.
+All changes to this template are documented in
+[CHANGELOG.md](https://github.com/kslides/kslides-template/blob/master/CHANGELOG.md)
+(structured per-version diff) and
+[RELEASE_NOTES.md](https://github.com/kslides/kslides-template/blob/master/RELEASE_NOTES.md)
+(narrative highlights). Check back occasionally for any changes that should be incorporated into your kslides repo.
 
 ## Creating Slide Content
 
@@ -105,8 +106,10 @@ Versions live in `gradle/libs.versions.toml`:
 
 ```toml
 [versions]
-kotlin = "2.1.20"
+ben-manes-versions = "0.54.0"
+kotlin = "2.3.21"
 kslides = "1.0.0"
+shadow = "9.4.1"
 
 [libraries]
 kslides-core = { module = "com.kslides:kslides-core", version.ref = "kslides" }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,11 +14,34 @@ and the Gradle version catalog. All plugin and library versions now live in
 `com.gradleup.shadow` fork (9.4.1). The `ben-manes-versions` plugin used by
 `make versioncheck` is now at 0.54.0.
 
+**Simpler fat-jar build.** The previous setup had a `shadowJar` task plus a
+`Jar` wrapper called `uberjar` that re-zipped the shadow output to give it
+a stable filename and a custom manifest. The wrapper is gone — `shadowJar`
+itself now produces `build/libs/kslides.jar` with the
+`Implementation-Title` / `Implementation-Version` / `Built-JDK` /
+`Main-Class` manifest attributes. `make uberjar` now invokes the
+`shadowJar` Gradle task directly. The output filename and manifest are
+unchanged, so `Procfile` and `make uber` keep working. The
+`shadowJar` task no longer excludes `LICENSE*`, so third-party license
+files are preserved in the uberjar.
+
+**`stage` task is now discoverable.** `gradle tasks` lists it under the
+`build` group with a description.
+
 A new `syncRevealJs` Gradle task unpacks the reveal.js assets bundled in
 the `kslides-core` JAR into `docs/revealjs/`, so static publishing targets
 like Netlify and GitHub Pages keep working when `kslides-core` ships
 updated reveal.js content. Run `make sync-revealjs` after a `kslides-core`
 upgrade.
+
+**Makefile polish.** All targets are declared `.PHONY` so they keep working
+once `build/` (or any other directory matching a target name) exists.
+`make uber` now honours `$PORT` (matching `Procfile`) and falls back to
+`8080` for local runs.
+
+`mavenLocal()` has been removed from both repository blocks in
+`settings.gradle.kts` — the build no longer resolves dependencies or
+plugins from a developer's local Maven cache.
 
 The README has been rewritten to document the Kotlin DSL + version-catalog
 setup (the old Groovy `build.gradle` snippet is gone). `LICENSE` was
@@ -31,7 +54,8 @@ removed.
 > **Forks:** mirror the new `build.gradle.kts`, `settings.gradle.kts`, and
 > `gradle/libs.versions.toml` into your fork (or regenerate from this
 > template) — there is no in-place migration path from the old Groovy
-> build.
+> build. If your downstream tooling invoked the `uberjar` Gradle task
+> directly, switch to `shadowJar`.
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,18 +5,33 @@ structured per-version diff, see [CHANGELOG.md](CHANGELOG.md).
 
 ---
 
-## Unreleased
+## v1.40.0 — 2026-04-29
 
 **Build modernization.** The project has migrated to the Gradle Kotlin DSL
 and the Gradle version catalog. All plugin and library versions now live in
-`gradle/libs.versions.toml`, the Gradle wrapper has been upgraded to 9.4.1,
-and the Shadow plugin has moved to the maintained `com.gradleup.shadow`
-fork (9.4.1).
+`gradle/libs.versions.toml`, the Gradle wrapper has been upgraded to
+**9.5.0**, and the Shadow plugin has moved to the maintained
+`com.gradleup.shadow` fork (9.4.1). The `ben-manes-versions` plugin used by
+`make versioncheck` is now at 0.54.0.
 
-A new `syncRevealJs` Gradle task unpacks the reveal.js assets bundled in the
-`kslides-core` JAR into `docs/revealjs/`, so static publishing targets like
-Netlify and GitHub Pages keep working when `kslides-core` ships updated
-reveal.js content.
+A new `syncRevealJs` Gradle task unpacks the reveal.js assets bundled in
+the `kslides-core` JAR into `docs/revealjs/`, so static publishing targets
+like Netlify and GitHub Pages keep working when `kslides-core` ships
+updated reveal.js content. Run `make sync-revealjs` after a `kslides-core`
+upgrade.
+
+The README has been rewritten to document the Kotlin DSL + version-catalog
+setup (the old Groovy `build.gradle` snippet is gone). `LICENSE` was
+renamed to `LICENSE.txt`. `CHANGELOG.md`, `RELEASE_NOTES.md`, and
+`CLAUDE.md` are now part of the template.
+
+The legacy `build.gradle`, `settings.gradle`, and `.travis.yml` have been
+removed.
+
+> **Forks:** mirror the new `build.gradle.kts`, `settings.gradle.kts`, and
+> `gradle/libs.versions.toml` into your fork (or regenerate from this
+> template) — there is no in-place migration path from the old Groovy
+> build.
 
 ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ application {
 
 // Change this to your name
 group = "com.github.username"
-version = "1.4.0"
+version = "1.40.0"
 
 dependencies {
     implementation(libs.kslides.core)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,9 @@ tasks.named<ShadowJar>("shadowJar") {
     }
 }
 
-tasks.register("stage") {
+tasks.register<DefaultTask>("stage") {
+    group = "build"
+    description = "Clean and build kslides.jar — invoked by Heroku via Procfile."
     dependsOn("clean", "shadowJar")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,21 +30,13 @@ kotlin {
     jvmToolchain(17)
 }
 
-tasks.withType<ShadowJar> {
+tasks.named<ShadowJar>("shadowJar") {
+    mustRunAfter("clean")
     isZip64 = true
     mergeServiceFiles()
     exclude("META-INF/*.SF")
     exclude("META-INF/*.DSA")
     exclude("META-INF/*.RSA")
-    exclude("LICENSE*")
-}
-
-val shadowJar = tasks.named<ShadowJar>("shadowJar")
-
-val uberjar = tasks.register<Jar>("uberjar") {
-    dependsOn(shadowJar)
-    mustRunAfter("clean")
-    isZip64 = true
     archiveFileName = "kslides.jar"
     manifest {
         attributes(
@@ -54,11 +46,10 @@ val uberjar = tasks.register<Jar>("uberjar") {
             "Main-Class" to mainName,
         )
     }
-    from(zipTree(shadowJar.flatMap { it.archiveFile }))
 }
 
 tasks.register("stage") {
-    dependsOn("clean", uberjar)
+    dependsOn("clean", "shadowJar")
 }
 
 // Unpack reveal.js assets from the kslides-core JAR into docs/revealjs/.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,6 @@ kslides-core = { module = "com.kslides:kslides-core", version.ref = "kslides" }
 kslides-letsplot = { module = "com.kslides:kslides-letsplot", version.ref = "kslides" }
 
 [plugins]
-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "ben-manes-versions" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,6 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         mavenCentral()
-        mavenLocal()
     }
 }
 
@@ -16,7 +15,6 @@ dependencyResolutionManagement {
     repositoriesMode = FAIL_ON_PROJECT_REPOS
     repositories {
         mavenCentral()
-        mavenLocal()
     }
 }
 


### PR DESCRIPTION
## Summary
- Bump template version to **1.40.0** (release date 2026-04-29).
- Document the release in `CHANGELOG.md` and `RELEASE_NOTES.md`.
- Refresh `README.md` for the Kotlin DSL setup: drop the dead Travis CI badge, bump the Kotlin badge to 2.3.21, sync the `libs.versions.toml` snippet, and cross-reference `RELEASE_NOTES.md`.

## Build polish
- Collapse the `uberjar` `Jar` wrapper into `shadowJar` itself — the fat jar is now produced directly at `build/libs/kslides.jar` with the custom manifest, eliminating one task and the `zipTree` indirection.
- Drop the `LICENSE*` exclusion from `shadowJar` so third-party LICENSE files survive in the uberjar (license-compliance fix).
- Use `tasks.withType<ShadowJar>().configureEach { … }` lazy configuration (now folded into the typed `tasks.named<ShadowJar>("shadowJar")` block).
- Give the `stage` task an explicit `DefaultTask` type, a `build` group, and a description so it surfaces under `gradle tasks`.
- Remove `mavenLocal()` from both repository blocks in `settings.gradle.kts`.
- Alphabetize `[plugins]` entries in `gradle/libs.versions.toml`.
- Bump the `ben-manes-versions` plugin to 0.54.0.

## Makefile polish
- Add `.PHONY` for every target.
- Simplify `build-all: clean stage` → `build-all: stage` (the Gradle `stage` task already depends on `clean`).
- Honour `$PORT` in `make uber` (matches `Procfile`, defaults to 8080 locally).
- Add inline comments explaining the `versioncheck` flag set and the `uber` PORT default.
- Point `make uberjar` at the `shadowJar` Gradle task (the `uberjar` Gradle task is gone).

## CLAUDE.md
- Cross-reference `RELEASE_NOTES.md` next to `CHANGELOG.md`.
- Tighten the release convention: maintainers update **both** changelog files and bump `version` in `build.gradle.kts` in the same commit.
- Drop the now-stale `LICENSE*`-exclusion caveat.

## Test plan
- [ ] `./gradlew tasks --all` resolves cleanly and lists `stage` under the `build` group with its description
- [ ] `./gradlew shadowJar` produces `build/libs/kslides.jar` with the custom manifest (`Implementation-Title`, `Implementation-Version=1.40.0`, `Built-JDK`, `Main-Class=SlidesKt`)
- [ ] `./gradlew stage` runs `clean` then `shadowJar` in order
- [ ] `make build-all` succeeds end-to-end
- [ ] `make uber` honours `PORT=9090 make uber` and falls back to 8080 with `make uber`
- [ ] `make versioncheck` runs cleanly with the `--no-configuration-cache --no-parallel` flags
- [ ] `make sync-revealjs` populates `docs/revealjs/` from the `kslides-core` JAR (and only that subtree)
- [ ] Smoke-test a Heroku deploy of the resulting `build/libs/kslides.jar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)