### PR TITLE
Backfill 1.32.0 changelog (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+*Nothing yet.*
+
 ## [1.40.0] - 2026-04-29
 
 ### Changed
@@ -34,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.travis.yml` (Travis CI config).
 - The `LICENSE*` exclusion in `shadowJar` — third-party LICENSE files are now preserved in the uberjar.
 - Standalone `uberjar` Gradle task (replaced by configuring `shadowJar` directly).
+
+## [1.32.0] - 2024-12-12
+
+### Changed
+- Updated to Kotlin 2.1.0.
+- Updated to Kotlin 2.0.0 and reveal.js 5.1.0 (rolled up from earlier in the cycle).
 
 ## [1.30.0] - 2023-11-01
 
@@ -182,7 +190,8 @@ released tag (1.2.1).
 - Repository created.
 
 [Unreleased]: https://github.com/kslides/kslides-template/compare/1.40.0...HEAD
-[1.40.0]: https://github.com/kslides/kslides-template/compare/1.30.0...1.40.0
+[1.40.0]: https://github.com/kslides/kslides-template/compare/1.32.0...1.40.0
+[1.32.0]: https://github.com/kslides/kslides-template/compare/1.30.0...1.32.0
 [1.30.0]: https://github.com/kslides/kslides-template/compare/1.10.0...1.30.0
 [1.10.0]: https://github.com/kslides/kslides-template/compare/1.9.0...1.10.0
 [1.9.0]: https://github.com/kslides/kslides-template/compare/1.8.0...1.9.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -59,6 +59,18 @@ removed.
 
 ---
 
+## v1.32.0 — 2024-12-12
+
+A maintenance roll-up covering 2024.
+
+- Kotlin **2.1.0** (this release).
+- Kotlin **2.0.0** and reveal.js **5.1.0** (landed mid-cycle and shipped
+  here for the first tagged release on that combo).
+
+No template structure changes — just dependency bumps.
+
+---
+
 ## v1.30.0 — 2023-11-01
 
 The big "modern reveal.js" refresh.


### PR DESCRIPTION
## Summary
- Add the missing **1.32.0** (2024-12-12) entry to `CHANGELOG.md` and `RELEASE_NOTES.md`. The 1.32.0 release covers Kotlin 2.0.0 / reveal.js 5.1.0 (mid-cycle) and Kotlin 2.1.0 (the named tag commit) with no template-structure changes.
- Update `CHANGELOG.md` compare links so `1.40.0` points at `1.32.0...1.40.0` and add `1.32.0` → `1.30.0...1.32.0`.
- Add a `*Nothing yet.*` placeholder under the `[Unreleased]` heading so the empty section is unambiguous.

## Test plan
- [ ] Render `CHANGELOG.md` on GitHub and confirm the 1.32.0 section sits between 1.40.0 and 1.30.0
- [ ] Confirm the compare links resolve to the right tag ranges
- [ ] Render `RELEASE_NOTES.md` on GitHub and confirm the 1.32.0 narrative renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)